### PR TITLE
Update docs about disabling transactions

### DIFF
--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -127,8 +127,8 @@ defmodule EctoEnumMigration do
   Checkout [Enumerated Types](https://www.postgresql.org/docs/current/datatype-enum.html)
   for more information.
 
-  Also it cannot be used inside a transaction block, we need to set
-  `@disable_ddl_transaction true` in the migration.
+  Also if running on a version of Postgres <= 11 then it cannot be used inside
+  a transaction block, so we need to set `@disable_ddl_transaction true` in the migration.
 
   ## Examples
 
@@ -136,6 +136,7 @@ defmodule EctoEnumMigration do
   defmodule MyApp.Repo.Migrations.AddValueToTypeMigration do
     use Ecto.Migration
     import EctoEnumMigration
+    # Only needed if running on Postgres <= 11
     @disable_ddl_transaction true
 
     def up do


### PR DESCRIPTION
Disabling transaction for `add_value_to_type` is only needed if running on Postgres <= 11
- The docs for Postgres 11 https://www.postgresql.org/docs/11/sql-altertype.html say
  - "ALTER TYPE ... ADD VALUE cannot be executed inside a transaction block."
- The docs for Postgres 12 say https://www.postgresql.org/docs/12/sql-altertype.html
  - "If ALTER TYPE ... ADD VALUE is executed inside a transaction block, the new value cannot be used until after the transaction has been committed."